### PR TITLE
add 相手と自分のクリック数を可視化した

### DIFF
--- a/_static/click_competition/progress_bar.css
+++ b/_static/click_competition/progress_bar.css
@@ -1,0 +1,12 @@
+.progress-container {
+    width: 100%;
+    background-color: #ddd;
+    margin: 10px 0;
+    height: 20px;
+}
+.progress-bar {
+    width: 0%;
+    height: 100%;
+    background-color: #4caf50;
+    transition: width 0.2s ease-in-out;
+}

--- a/click_competition/ClickPage.html
+++ b/click_competition/ClickPage.html
@@ -2,11 +2,26 @@
 
 <h2>クリックしてスコアを競おう！</h2>
 <p>あなたのクリック数: <span id="my-clicks">0</span></p>
-<p>対戦相手のクリック数: <span id="opponent-clicks">0</span></p>
-<button id="click-button" type="button">クリック！</button>
+<div class="progress-container">
+    <div id="my-progress" class="progress-bar"></div>
+</div>
 
+<p>対戦相手のクリック数: <span id="opponent-clicks">0</span></p>
+<div class="progress-container">
+    <div id="opponent-progress" class="progress-bar"></div>
+</div>
+
+<button id="click-button" type="button" class="btn btn-primary">
+    クリック！
+</button>
+
+<link
+    rel="stylesheet"
+    href="{{ static 'click_competition/progress_bar.css'}}"
+/>
 <script>
     let myClicks = 0;
+    const MAX_CLICKS = 100;
     let my_id = "{{my_id}}";
     let opponent_id = "{{opponent_id}}";
 
@@ -14,14 +29,23 @@
         .getElementById("click-button")
         .addEventListener("click", function () {
             myClicks++;
-            document.getElementById("my-clicks").textContent = myClicks;
+            updateProgress("my-clicks", "my-progress", myClicks);
             liveSend({ action: "click" });
         });
 
+    function updateProgress(counterId, progressId, value) {
+        document.getElementById(counterId).textContent = value;
+        let percentage = Math.min((value / MAX_CLICKS) * 100, 100);
+        document.getElementById(progressId).style.width = percentage + "%";
+    }
+
     function liveRecv(data) {
         console.log(data);
-        document.getElementById("opponent-clicks").textContent =
-            data[opponent_id];
+        updateProgress(
+            "opponent-clicks",
+            "opponent-progress",
+            data[opponent_id]
+        );
     }
 </script>
 {{endblock}}

--- a/click_competition/__init__.py
+++ b/click_competition/__init__.py
@@ -10,7 +10,7 @@ Your app description
 class C(BaseConstants):
     NAME_IN_URL = "click_competition"
     PLAYERS_PER_GROUP = 2
-    NUM_ROUNDS = 10
+    NUM_ROUNDS = 1000
 
 
 class Subsession(BaseSubsession):


### PR DESCRIPTION
This pull request includes several changes to enhance the click competition feature by adding a progress bar, updating the number of rounds, and improving the user interface. The most important changes include the addition of a progress bar to the HTML and CSS files, updating the JavaScript to handle the progress bar, and increasing the number of rounds in the competition.

Enhancements to the user interface:

* [`_static/click_competition/progress_bar.css`](diffhunk://#diff-9043b6919db822d5879234b54597e75bb6211a554c733d79cedf35976d6b6b44R1-R12): Added CSS styles for the progress bar, including the container and bar elements.
* [`click_competition/ClickPage.html`](diffhunk://#diff-6689eb47610952cefd9ec046e8700f8e735bef675fb0fedb9d6e69f95934c697R5-R48): Integrated the progress bar into the HTML structure for both the user and the opponent, and linked the new CSS file.

JavaScript updates:

* [`click_competition/ClickPage.html`](diffhunk://#diff-6689eb47610952cefd9ec046e8700f8e735bef675fb0fedb9d6e69f95934c697R5-R48): Updated the JavaScript to include the `updateProgress` function, which updates the progress bar based on the number of clicks.

Configuration changes:

* [`click_competition/__init__.py`](diffhunk://#diff-3f95d426936f079fefa8e496180877a9f71ca15ab8462630b5226155d0ed3ebaL13-R13): Increased the number of rounds from 10 to 1000 to allow for longer competitions.